### PR TITLE
Add retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Installs packages specified with the `packages` option. It leverages caching to 
 # Options
 
 * `packages`: (required) The name(s) of the packages to install. Separate packages using a space.
+* `clear-cache`: (optional) Clears the Wercker cache when retrying. Set to `true` by default.
+
 
 # Example
 

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,39 @@
-export APT_LIST_PATH=$WERCKER_CACHE_DIR/wercker/apt-lists
-mkdir -p $APT_LIST_PATH
-sudo rm -fr /var/lib/apt/lists
-sudo ln -s $APT_LIST_PATH/ /var/lib/apt/lists
-if [ $( find $WERCKER_CACHE_DIR/wercker/aptupdated -mtime -1 | wc -l ) -eq 0 ] ;
-then sudo apt-get update; touch $WERCKER_CACHE_DIR/wercker/aptupdated;  fi
+APT_LIST_PATH=$WERCKER_CACHE_DIR/wercker/apt-lists
+MAX_TRIES=3
+try=1
 
-sudo apt-get install $WERCKER_INSTALL_PACKAGES_PACKAGES -y
+retry() {
+
+    try=$((try+1))
+
+    if [ "$try" -gt "$MAX_TRIES" ]; then
+        fail "Retry exceeds max retries";
+    fi
+
+    if [ "$WERCKER_INSTALL_PACKAGES_CLEAR_CACHE" = "true" ]; then
+        info "Clearing the cache: $WERCKER_CACHE_DIR/wercker"
+        rm -f $WERCKER_CACHE_DIR/wercker/aptupdated && rm -rf $APT_LIST_PATH
+    else
+        info "Skipping clearing cache; WERCKER_INSTALL_PACKAGES_CLEAR_CACHE is not set to true";
+    fi
+
+    info "Retrying apt-get-install, try: $try";
+    exec_install_packages;
+}
+
+exec_install_packages(){
+  mkdir -p $APT_LIST_PATH
+  sudo rm -fr /var/lib/apt/lists
+  sudo ln -s $APT_LIST_PATH/ /var/lib/apt/lists
+  if [ $( find $WERCKER_CACHE_DIR/wercker/aptupdated -mtime -1 | wc -l ) -eq 0 ] ;
+  then sudo apt-get update; touch $WERCKER_CACHE_DIR/wercker/aptupdated;  fi
+
+  sudo apt-get install $WERCKER_INSTALL_PACKAGES_PACKAGES -y
+
+  if [[ $? -ne 0 ]]; then
+    info "Unable to execute apt-get-install"
+    retry
+  fi
+}
+
+exec_install_packages

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,8 +1,13 @@
 name: install-packages
-version: 0.0.4
+version: 1.0.0
 description: install-packages step
 keywords:
   - apt-get
   - update
   - install
   - packages
+properties:
+  clear-cache:
+    type: string
+    required: false
+    default: "true"


### PR DESCRIPTION
This PR supports retrying running `install-packages` on failure and optionally clearing the cache using the `clear-cache:true` property (set to `true` by default).